### PR TITLE
Change source stop semantics

### DIFF
--- a/proto/connector/v1/connector.proto
+++ b/proto/connector/v1/connector.proto
@@ -8,220 +8,230 @@ import "google/protobuf/struct.proto";
 // Record represents a single data record produced by a source and/or consumed
 // by a destination connector.
 message Record {
-    // Position uniquely represents the record.
-    bytes position = 1;
-    // Metadata contains additional information regarding the record.
-    map<string, string> metadata = 2;
-    // Created at represents the time when the change occurred in the source
-    // system. If that's impossible to find out, then it should be the time the
-    // change was detected by the connector.
-    google.protobuf.Timestamp created_at = 3;
-    // Key represents a value that should be the same for records originating
-    // from the same source entry (e.g. same DB row).
-    Data key = 4;
-    // Payload holds the actual information that the record is transmitting.
-    Data payload = 5;
+  // Position uniquely represents the record.
+  bytes position = 1;
+  // Metadata contains additional information regarding the record.
+  map<string, string> metadata = 2;
+  // Created at represents the time when the change occurred in the source
+  // system. If that's impossible to find out, then it should be the time the
+  // change was detected by the connector.
+  google.protobuf.Timestamp created_at = 3;
+  // Key represents a value that should be the same for records originating
+  // from the same source entry (e.g. same DB row).
+  Data key = 4;
+  // Payload holds the actual information that the record is transmitting.
+  Data payload = 5;
 }
 
 // Data is used to represent the record key and payload. It can be either raw
 // data (byte array) or structured data (struct).
 message Data {
-    oneof data {
-        // Raw data contains unstructured data in form of a byte array.
-        bytes raw_data = 1;
-        // Structured data contains data in form of a struct with fields.
-        google.protobuf.Struct structured_data = 2;
-    }
+  oneof data {
+    // Raw data contains unstructured data in form of a byte array.
+    bytes raw_data = 1;
+    // Structured data contains data in form of a struct with fields.
+    google.protobuf.Struct structured_data = 2;
+  }
 }
 
 // SourcePlugin is responsible for fetching records from 3rd party resources and
 // sending them to Conduit.
 service SourcePlugin {
-    // Configure is the first function to be called in a plugin. It provides the
-    // plugin with the configuration that needs to be validated and stored. In
-    // case the configuration is not valid it should return an error status.
-    rpc Configure(Source.Configure.Request) returns (Source.Configure.Response);
-    // Start is called after Configure to signal the plugin it can prepare to
-    // start producing records. If needed, the plugin should open connections in
-    // this function. The position parameter will contain the position of the
-    // last record that was successfully processed. The Source should therefore
-    // start producing records after this position.
-    rpc Start(Source.Start.Request) returns (Source.Start.Response);
-    // Run will open a bidirectional stream between Conduit and the plugin.
-    // The plugin is responsible for fetching records from 3rd party resources
-    // and sending them as responses to Conduit. Conduit will process the
-    // records asynchronously and send acknowledgments back to the plugin to
-    // signal that a record at a certain position was processed. The plugin is
-    // responsible for keeping track of how many acknowledgments are still
-    // outstanding and should stop the stream only after all acknowledgments
-    // were received.
-    rpc Run(stream Source.Run.Request) returns (stream Source.Run.Response);
-    // Stop signals to the plugin to stop retrieving new records and flush any
-    // records that might be cached. The stream should will still remain open so
-    // Conduit can fetch the remaining records and send back any outstanding
-    // acknowledgments. After all acknowledgments are received the plugin should
-    // close the stream.
-    rpc Stop(Source.Stop.Request) returns (Source.Stop.Response);
-    // Teardown signals to the plugin that there will be no more calls to any
-    // other function. After Teardown returns, the plugin should be ready for a
-    // graceful shutdown.
-    rpc Teardown(Source.Teardown.Request) returns (Source.Teardown.Response);
+  // Configure is the first function to be called in a plugin. It provides the
+  // plugin with the configuration that needs to be validated and stored. In
+  // case the configuration is not valid it should return an error status.
+  rpc Configure(Source.Configure.Request) returns (Source.Configure.Response);
+  // Start is called after Configure to signal the plugin it can prepare to
+  // start producing records. If needed, the plugin should open connections in
+  // this function. The position parameter will contain the position of the
+  // last record that was successfully processed. The Source should therefore
+  // start producing records after this position.
+  rpc Start(Source.Start.Request) returns (Source.Start.Response);
+  // Run will open a bidirectional stream between Conduit and the plugin.
+  // The plugin is responsible for fetching records from 3rd party resources
+  // and sending them as responses to Conduit. Conduit will process the
+  // records asynchronously and send acknowledgments back to the plugin to
+  // signal that a record at a certain position was processed. Acknowledgments
+  // will be sent back to the connector in the same order as the records
+  // produced by the connector. If a record could not be processed by Conduit,
+  // the stream will be closed without an acknowledgment being sent back to the
+  // connector.
+  rpc Run(stream Source.Run.Request) returns (stream Source.Run.Response);
+  // Stop signals to the plugin to stop retrieving new records and flush any
+  // records that might be cached into the stream. It should block until it can
+  // determine the last record that will be sent to the stream and return the
+  // position of the last record. Conduit will keep the stream open until it
+  // receives the last record and sends back any outstanding acknowledgments.
+  // If Conduit did not send an acknowledgment for a record after the stream is
+  // closed, it should be interpreted as a negative acknowledgment.
+  rpc Stop(Source.Stop.Request) returns (Source.Stop.Response);
+  // Teardown signals to the plugin that there will be no more calls to any
+  // other function. After Teardown returns, the plugin should be ready for a
+  // graceful shutdown.
+  rpc Teardown(Source.Teardown.Request) returns (Source.Teardown.Response);
 }
 
 // DestinationPlugin is responsible for writing records to 3rd party resources.
 service DestinationPlugin {
-    // Configure is the first function to be called in a plugin. It provides the
-    // plugin with the configuration that needs to be validated and stored. In
-    // case the configuration is not valid it should return an error status.
-    rpc Configure(Destination.Configure.Request) returns (Destination.Configure.Response);
-    // Start is called after Configure to signal the plugin it can prepare to
-    // start writing records. If needed, the plugin should open connections in
-    // this function.
-    rpc Start(Destination.Start.Request) returns (Destination.Start.Response);
-    // Run will open a bidirectional stream between Conduit and the plugin.
-    // Conduit will be streaming records to the plugin that should be written
-    // to the 3rd party resource. The plugin is responsible for sending
-    // acknowledgments back to Conduit once a record has been processed. The
-    // acknowledgment should contain an error in case a record could not be
-    // successfully processed. The stream should still stay open in case Conduit
-    // is able to recover from the error and the pipeline keeps running.
-    rpc Run(stream Destination.Run.Request) returns (stream Destination.Run.Response);
-    // Stop signals to the plugin that no more records will be written to the
-    // stream. The plugin should flush any records that might be cached and not
-    // yet written to the 3rd party resource.
-    rpc Stop(Destination.Stop.Request) returns (Destination.Stop.Response);
-    // Teardown signals to the plugin that there will be no more calls to any
-    // other function. After Teardown returns, the plugin should be ready for a
-    // graceful shutdown.
-    rpc Teardown(Destination.Teardown.Request) returns (Destination.Teardown.Response);
+  // Configure is the first function to be called in a plugin. It provides the
+  // plugin with the configuration that needs to be validated and stored. In
+  // case the configuration is not valid it should return an error status.
+  rpc Configure(Destination.Configure.Request) returns (Destination.Configure.Response);
+  // Start is called after Configure to signal the plugin it can prepare to
+  // start writing records. If needed, the plugin should open connections in
+  // this function.
+  rpc Start(Destination.Start.Request) returns (Destination.Start.Response);
+  // Run will open a bidirectional stream between Conduit and the plugin.
+  // Conduit will be streaming records to the plugin that should be written
+  // to the 3rd party resource. The plugin is responsible for sending
+  // acknowledgments back to Conduit once a record has been processed. The
+  // acknowledgment should contain an error in case a record could not be
+  // successfully processed. The stream should still stay open in case Conduit
+  // is able to recover from the error and the pipeline keeps running.
+  rpc Run(stream Destination.Run.Request) returns (stream Destination.Run.Response);
+  // Stop signals to the plugin that no more records will be written to the
+  // stream. The plugin should flush any records that might be cached and not
+  // yet written to the 3rd party resource.
+  rpc Stop(Destination.Stop.Request) returns (Destination.Stop.Response);
+  // Teardown signals to the plugin that there will be no more calls to any
+  // other function. After Teardown returns, the plugin should be ready for a
+  // graceful shutdown.
+  rpc Teardown(Destination.Teardown.Request) returns (Destination.Teardown.Response);
 }
 
 // SpecifierPlugin is responsible for returning the plugin specification.
 service SpecifierPlugin {
-    // Specify should return the plugin specification.
-    rpc Specify(Specifier.Specify.Request) returns (Specifier.Specify.Response);
+  // Specify should return the plugin specification.
+  rpc Specify(Specifier.Specify.Request) returns (Specifier.Specify.Response);
 }
 
 message Source {
-    message Configure {
-        message Request {
-            // Config contains the raw plugin settings.
-            map<string, string> config = 1;
-        }
-        message Response {}
+  message Configure {
+    message Request {
+      // Config contains the raw plugin settings.
+      map<string, string> config = 1;
     }
+    message Response {}
+  }
 
-    message Start {
-        message Request {
-            // This is the position of the last record that was successfully
-            // processed. The Source should start producing records after this
-            // position.
-            bytes position = 1;
-        }
-        message Response {}
+  message Start {
+    message Request {
+      // This is the position of the last record that was successfully
+      // processed. The Source should start producing records after this
+      // position.
+      bytes position = 1;
     }
+    message Response {}
+  }
 
-    message Run {
-        message Request {
-            // This is the position of the record that was successfully
-            // processed.
-            bytes ack_position = 1;
-        }
-        message Response {
-            // Record contains the record read by the source from the 3rd party
-            // resource.
-            Record record = 1;
-        }
+  message Run {
+    message Request {
+      // This is the position of the record that was successfully
+      // processed.
+      bytes ack_position = 1;
     }
+    message Response {
+      // Record contains the record read by the source from the 3rd party
+      // resource.
+      Record record = 1;
+    }
+  }
 
-    message Stop {
-        message Request {}
-        message Response {}
+  message Stop {
+    message Request {}
+    message Response {
+      // This is the position of the last record in the stream, Conduit
+      // won't process records after this position anymore. After the
+      // record with this position is received by Conduit and all
+      // outstanding acknowledgments were delivered to the connector, the
+      // stream will be closed.
+      bytes last_position = 1;
     }
+  }
 
-    message Teardown {
-        message Request {}
-        message Response {}
-    }
+  message Teardown {
+    message Request {}
+    message Response {}
+  }
 }
 
 message Destination {
-    message Configure {
-        message Request {
-            // Config contains the raw plugin settings.
-            map<string, string> config = 1;
-        }
-        message Response {}
+  message Configure {
+    message Request {
+      // Config contains the raw plugin settings.
+      map<string, string> config = 1;
     }
+    message Response {}
+  }
 
-    message Start {
-        message Request {}
-        message Response {}
-    }
+  message Start {
+    message Request {}
+    message Response {}
+  }
 
-    message Run {
-        message Request {
-            // Record contains the record that should be written to the 3rd
-            // party resource.
-            Record record = 1;
-        }
-        message Response {
-            // This is the position of the record that was processed.
-            bytes ack_position = 1;
-            // Error should be empty if the record was successfully processed or
-            // should contain a descriptive message in case the record
-            // processing failed.
-            string error = 2;
-        }
+  message Run {
+    message Request {
+      // Record contains the record that should be written to the 3rd
+      // party resource.
+      Record record = 1;
     }
+    message Response {
+      // This is the position of the record that was processed.
+      bytes ack_position = 1;
+      // Error should be empty if the record was successfully processed or
+      // should contain a descriptive message in case the record
+      // processing failed.
+      string error = 2;
+    }
+  }
 
-    message Stop {
-        message Request {}
-        message Response {}
-    }
+  message Stop {
+    message Request {}
+    message Response {}
+  }
 
-    message Teardown {
-        message Request {}
-        message Response {}
-    }
+  message Teardown {
+    message Request {}
+    message Response {}
+  }
 }
 
 message Specifier {
-    message Specify {
-        message Request {}
-        message Response {
-            // Name is the name of the plugin.
-            string name = 1;
-            // Summary is a brief description of the plugin and what it does,
-            // ideally not longer than one sentence.
-            string summary = 2;
-            // Description is a longer form field, appropriate for README-like
-            // text that the author can provide for documentation about the
-            // usage of the plugin.
-            string description = 3;
-            // Version string. Should follow semantic versioning and use the "v"
-            // prefix (e.g. v1.23.4).
-            string version = 4;
-            // Author declares the entity that created or maintains this plugin.
-            string author = 5;
-            // A map that describes parameters available for configuring the
-            // destination plugin.
-            map<string, Parameter> destination_params = 6;
-            // A map that describes parameters available for configuring the
-            // source plugin.
-            map<string, Parameter> source_params = 7;
-        }
+  message Specify {
+    message Request {}
+    message Response {
+      // Name is the name of the plugin.
+      string name = 1;
+      // Summary is a brief description of the plugin and what it does,
+      // ideally not longer than one sentence.
+      string summary = 2;
+      // Description is a longer form field, appropriate for README-like
+      // text that the author can provide for documentation about the
+      // usage of the plugin.
+      string description = 3;
+      // Version string. Should follow semantic versioning and use the "v"
+      // prefix (e.g. v1.23.4).
+      string version = 4;
+      // Author declares the entity that created or maintains this plugin.
+      string author = 5;
+      // A map that describes parameters available for configuring the
+      // destination plugin.
+      map<string, Parameter> destination_params = 6;
+      // A map that describes parameters available for configuring the
+      // source plugin.
+      map<string, Parameter> source_params = 7;
     }
+  }
 
-    // Parameter describes a single config parameter.
-    message Parameter {
-        // Default is the default value of the parameter. If there is no default
-        // value use an empty string.
-        string default = 1;
-        // Required defines whether the parameter has to be provided when
-        // configuring the plugin.
-        bool required = 2;
-        // Description explains what the parameter does and how to configure it.
-        string description = 3;
-    }
+  // Parameter describes a single config parameter.
+  message Parameter {
+    // Default is the default value of the parameter. If there is no default
+    // value use an empty string.
+    string default = 1;
+    // Required defines whether the parameter has to be provided when
+    // configuring the plugin.
+    bool required = 2;
+    // Description explains what the parameter does and how to configure it.
+    string description = 3;
+  }
 }


### PR DESCRIPTION
This changes the semantics of the source connector stop. See comment for `SourcePlugin.Stop` and `SourcePlugin.Run`.

It also introduces the field `Source.Stop.Response.last_position` (see comment for more info).