### PR TITLE
OpenCDC protobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/internal

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
   go_package_prefix:
-    default: github.com/conduitio/conduit-connector-protocol/internal
+    default: go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol
 plugins:
   - name: go
     out: ../internal

--- a/proto/connector/v1/connector.proto
+++ b/proto/connector/v1/connector.proto
@@ -2,7 +2,20 @@ syntax = "proto3";
 
 package connector.v1;
 
+import "google/protobuf/descriptor.proto";
 import "opencdc/v1/opencdc.proto";
+
+option (metadata_conduit_version) = "conduit.version";
+option (metadata_conduit_plugin_name) = "conduit.plugin.name";
+option (metadata_conduit_plugin_version) = "conduit.plugin.version";
+
+// We are (ab)using custom file options to define constants.
+// See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
+extend google.protobuf.FileOptions {
+  string metadata_conduit_version = 20000;
+  string metadata_conduit_plugin_name = 20001;
+  string metadata_conduit_plugin_version = 20002;
+}
 
 // SourcePlugin is responsible for fetching records from 3rd party resources and
 // sending them to Conduit.

--- a/proto/connector/v1/connector.proto
+++ b/proto/connector/v1/connector.proto
@@ -5,16 +5,14 @@ package connector.v1;
 import "google/protobuf/descriptor.proto";
 import "opencdc/v1/opencdc.proto";
 
-option (metadata_conduit_version) = "conduit.version";
 option (metadata_conduit_plugin_name) = "conduit.plugin.name";
 option (metadata_conduit_plugin_version) = "conduit.plugin.version";
 
 // We are (ab)using custom file options to define constants.
 // See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
 extend google.protobuf.FileOptions {
-  string metadata_conduit_version = 20000;
-  string metadata_conduit_plugin_name = 20001;
-  string metadata_conduit_plugin_version = 20002;
+  string metadata_conduit_plugin_name = 20000;
+  string metadata_conduit_plugin_version = 20001;
 }
 
 // SourcePlugin is responsible for fetching records from 3rd party resources and

--- a/proto/connector/v1/connector.proto
+++ b/proto/connector/v1/connector.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package connector.v1;
 
-import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 // Record represents a single data record produced by a source and/or consumed
 // by a destination connector.

--- a/proto/connector/v1/connector.proto
+++ b/proto/connector/v1/connector.proto
@@ -2,37 +2,7 @@ syntax = "proto3";
 
 package connector.v1;
 
-import "google/protobuf/struct.proto";
-import "google/protobuf/timestamp.proto";
-
-// Record represents a single data record produced by a source and/or consumed
-// by a destination connector.
-message Record {
-  // Position uniquely represents the record.
-  bytes position = 1;
-  // Metadata contains additional information regarding the record.
-  map<string, string> metadata = 2;
-  // Created at represents the time when the change occurred in the source
-  // system. If that's impossible to find out, then it should be the time the
-  // change was detected by the connector.
-  google.protobuf.Timestamp created_at = 3;
-  // Key represents a value that should be the same for records originating
-  // from the same source entry (e.g. same DB row).
-  Data key = 4;
-  // Payload holds the actual information that the record is transmitting.
-  Data payload = 5;
-}
-
-// Data is used to represent the record key and payload. It can be either raw
-// data (byte array) or structured data (struct).
-message Data {
-  oneof data {
-    // Raw data contains unstructured data in form of a byte array.
-    bytes raw_data = 1;
-    // Structured data contains data in form of a struct with fields.
-    google.protobuf.Struct structured_data = 2;
-  }
-}
+import "opencdc/v1/opencdc.proto";
 
 // SourcePlugin is responsible for fetching records from 3rd party resources and
 // sending them to Conduit.
@@ -132,9 +102,9 @@ message Source {
       bytes ack_position = 1;
     }
     message Response {
-      // Record contains the record read by the source from the 3rd party
-      // resource.
-      Record record = 1;
+      // Record contains the OpenCDC record read by the source from the 3rd
+      // party resource.
+      opencdc.v1.Record record = 1;
     }
   }
 
@@ -172,9 +142,9 @@ message Destination {
 
   message Run {
     message Request {
-      // Record contains the record that should be written to the 3rd
+      // Record contains the OpenCDC record that should be written to the 3rd
       // party resource.
-      Record record = 1;
+      opencdc.v1.Record record = 1;
     }
     message Response {
       // This is the position of the record that was processed.

--- a/proto/opencdc/v1/opencdc.proto
+++ b/proto/opencdc/v1/opencdc.proto
@@ -42,8 +42,8 @@ message Record {
   // possibilities: create, update, delete or snapshot. The first three
   // operations are encountered during normal CDC operation, while "snapshot" is
   // meant to represent records during an initial load. Depending on the
-  // operation, the record will contain either the state before the change,
-  // after the change, or both (see fields before and after).
+  // operation, the record will contain either the payload before the change,
+  // after the change, or both (see field payload).
   Operation operation = 2;
 
   // Metadata contains optional information related to the record. Although the
@@ -51,23 +51,22 @@ message Record {
   // metadata fields (see options prefixed with metadata_*).
   map<string, string> metadata = 3;
 
-  // Before contains the state of the entity before the operation occurred. This
-  // field will only be populated for operations "update" and "delete".
-  Entity before = 4;
-  // After contains the state of the entity after the operation occurred. This
-  // field will only be populated for operations "create", "update" and
-  // "snapshot".
-  Entity after = 5;
+  // Key represents a value that should identify the entity (e.g. database row).
+  Data key = 4;
+  // Payload holds the payload change (data before and after the operation
+  // occurred).
+  Change payload = 5;
 }
 
-// Entity represents the state of the entity at a specific point in time.
-message Entity {
-  // Key represents a value that should identify the entity (e.g. database row).
-  Data key = 1;
-  // Payload holds the actual data of the entity.
-  // If the key and payload both contain structured data it is preferable not to
-  // include the key data in the payload data.
-  Data payload = 2;
+// Change represents the data before and after the operation occurred.
+message Change {
+  // Before contains the data before the operation occurred. This field is
+  // optional and should only be populated for operations "update" and "delete"
+  // (if the system supports fetching the data before the operation).
+  Data before = 1;
+  // After contains the data after the operation occurred. This field should be
+  // populated for all operations except "delete".
+  Data after = 2;
 }
 
 // Data is used to represent the record key and payload. It can be either raw

--- a/proto/opencdc/v1/opencdc.proto
+++ b/proto/opencdc/v1/opencdc.proto
@@ -5,6 +5,9 @@ package opencdc.v1;
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/struct.proto";
 
+// Version contains the version of the OpenCDC format. The value is formatted as
+// a semantic version prefixed with "v" (e.g. "v1.0.0").
+option (metadata_version) = "opencdc.version";
 // CreatedAt can contain the time when the record was created in the 3rd party
 // system. The expected format is a unix timestamp in nanoseconds.
 option (metadata_created_at) = "opencdc.createdAt";
@@ -15,8 +18,9 @@ option (metadata_read_at) = "opencdc.readAt";
 // We are (ab)using custom file options to define constants.
 // See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
 extend google.protobuf.FileOptions {
-  string metadata_created_at = 10000;
-  string metadata_read_at = 10001;
+  string metadata_version = 10000;
+  string metadata_created_at = 10001;
+  string metadata_read_at = 10002;
 }
 
 // Operation defines what triggered the creation of a record.

--- a/proto/opencdc/v1/opencdc.proto
+++ b/proto/opencdc/v1/opencdc.proto
@@ -1,0 +1,83 @@
+syntax = "proto3";
+
+package opencdc.v1;
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/struct.proto";
+
+// CreatedAt can contain the time when the record was created in the 3rd party
+// system. The expected format is a unix timestamp in nanoseconds.
+option (metadata_created_at) = "opencdc.createdAt";
+// ReadAt can contain the time when the record was read from the 3rd party
+// system. The expected format is a unix timestamp in nanoseconds.
+option (metadata_read_at) = "opencdc.readAt";
+
+// We are (ab)using custom file options to define constants.
+// See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
+extend google.protobuf.FileOptions {
+  string metadata_created_at = 1000;
+  string metadata_read_at = 1001;
+}
+
+// Operation defines what triggered the creation of a record.
+enum Operation {
+  OPERATION_UNSPECIFIED = 0;
+  // Records with operation create contain data of a newly created entity.
+  OPERATION_CREATE = 1;
+  // Records with operation update contain data of an updated entity.
+  OPERATION_UPDATE = 2;
+  // Records with operation delete contain data of a deleted entity.
+  OPERATION_DELETE = 3;
+  // Records with operation snapshot contain data of a previously existing
+  // entity, fetched as part of a snapshot.
+  OPERATION_SNAPSHOT = 4;
+}
+
+// Record contains data about a single change event related to a single entity.
+message Record {
+  // Position uniquely identifies the record.
+  bytes position = 1;
+
+  // Operation defines what triggered the creation of a record. There are four
+  // possibilities: create, update, delete or snapshot. The first three
+  // operations are encountered during normal CDC operation, while "snapshot" is
+  // meant to represent records during an initial load. Depending on the
+  // operation, the record will contain either the state before the change,
+  // after the change, or both (see fields before and after).
+  Operation operation = 2;
+
+  // Metadata contains optional information related to the record. Although the
+  // map can contain arbitrary keys, the standard provides a set of standard
+  // metadata fields (see options prefixed with metadata_*).
+  map<string, string> metadata = 3;
+
+  // Before contains the state of the entity before the operation occurred. This
+  // field will only be populated for operations "update" and "delete".
+  Entity before = 4;
+  // After contains the state of the entity after the operation occurred. This
+  // field will only be populated for operations "create", "update" and
+  // "snapshot".
+  Entity after = 5;
+}
+
+// Entity represents the state of the entity at a specific point in time.
+message Entity {
+  // Key represents a value that should identify the entity (e.g. database row).
+  Data key = 1;
+  // Payload holds the actual data of the entity.
+  // If the key and payload both contain structured data it is preferable not to
+  // include the key data in the payload data.
+  Data payload = 2;
+}
+
+// Data is used to represent the record key and payload. It can be either raw
+// data (byte array) or structured data (struct).
+message Data {
+  oneof data {
+    // Raw data contains unstructured data in form of a byte array.
+    bytes raw_data = 1;
+    // Structured data contains data in form of a struct with fields.
+    google.protobuf.Struct structured_data = 2;
+  }
+  // TODO schema will be added here in future iterations.
+}

--- a/proto/opencdc/v1/opencdc.proto
+++ b/proto/opencdc/v1/opencdc.proto
@@ -15,8 +15,8 @@ option (metadata_read_at) = "opencdc.readAt";
 // We are (ab)using custom file options to define constants.
 // See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
 extend google.protobuf.FileOptions {
-  string metadata_created_at = 1000;
-  string metadata_read_at = 1001;
+  string metadata_created_at = 10000;
+  string metadata_read_at = 10001;
 }
 
 // Operation defines what triggered the creation of a record.

--- a/proto/opencdc/v1/opencdc.proto
+++ b/proto/opencdc/v1/opencdc.proto
@@ -5,8 +5,15 @@ package opencdc.v1;
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/struct.proto";
 
-// Version contains the version of the OpenCDC format. The value is formatted as
-// a semantic version prefixed with "v" (e.g. "v1.0.0").
+// OpenCDC version is a constant that should be used as the value in the
+// metadata field opencdc.version. It ensures the OpenCDC format version can be
+// easily identified in case the record gets marshaled into a different untyped
+// format (e.g. JSON).
+option (opencdc_version) = "v1";
+
+// Version contains the version of the OpenCDC format (e.g. "v1"). This field
+// exists to ensure the OpenCDC format version can be easily identified in case
+// the record gets marshaled into a different untyped format (e.g. JSON).
 option (metadata_version) = "opencdc.version";
 // CreatedAt can contain the time when the record was created in the 3rd party
 // system. The expected format is a unix timestamp in nanoseconds.
@@ -18,6 +25,8 @@ option (metadata_read_at) = "opencdc.readAt";
 // We are (ab)using custom file options to define constants.
 // See https://github.com/protocolbuffers/protobuf/issues/3520#issuecomment-323613839
 extend google.protobuf.FileOptions {
+  string opencdc_version = 9999;
+
   string metadata_version = 10000;
   string metadata_created_at = 10001;
   string metadata_read_at = 10002;


### PR DESCRIPTION
This PR creates the OpenCDC protobuf definition. It follows the [design document](https://github.com/ConduitIO/conduit/blob/main/docs/design-documents/20220309-opencdc.md) with one notable difference - the operation "insert" was changed to "create", to make the terminology a bit more generic ("insert" sounds database specific).

File options have been used to create constants for common metadata fields. We can add more fields in the future. In Go these options can be accessed like this:
```
proto.GetExtension(File_opencdc_v1_opencdc_proto.Options(), E_MetadataCreatedAt)
```

The idea is to use this to create global variables in the Go binding:
```
var (
	MetadataCreatedAt string
	MetadataReadAt    string
)

func init() {
	MetadataCreatedAt = proto.GetExtension(File_opencdc_v1_opencdc_proto.Options(), E_MetadataCreatedAt).(string)
	MetadataReadAt = proto.GetExtension(File_opencdc_v1_opencdc_proto.Options(), E_MetadataReadAt).(string)
}
```

Closes https://github.com/ConduitIO/conduit/issues/507 and closes https://github.com/ConduitIO/conduit/issues/508.