### PR TITLE
OpenCDC Go binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,33 @@
 > **If you want to implement a Conduit connector in Go, you should use the
 [Connector SDK](https://github.com/ConduitIO/conduit-connector-sdk).**
 
-This repository contains the definition of the [Conduit](https://github.com/conduitio/conduit) connector protocol in gRPC.
-It also contains a thin Go layer that hides the gRPC implementation details without adding any functionality on top.
+This repository contains the definition of
+the [Conduit](https://github.com/conduitio/conduit) connector protocol in gRPC.
+It also contains a thin Go layer that hides the gRPC implementation details
+without adding any functionality on top.
 
-This repository is the only connection point between Conduit and a connector connector.
+This repository is the only connection point between Conduit and a connector
+connector.
 
 ## Implementing a connector in Go
 
-We provide a [Connector SDK](https://github.com/ConduitIO/conduit-connector-sdk) for writing connectors in Go. In
-this case you won't directly use the contents of this repository, instead the SDK hides implementation details and
-provides utilities to make developing a connector as simple as possible.
+We provide a [Connector SDK](https://github.com/ConduitIO/conduit-connector-sdk)
+for writing connectors in Go. In this case you won't directly use the contents
+of this repository, instead the SDK hides implementation details and provides
+utilities to make developing a connector as simple as possible.
 
-If you want to implement a connector in any other language you will need to generate the protocol code yourself,
-this is explained in the next chapter.
+If you want to implement a connector in any other language you will need to
+generate the protocol code yourself, this is explained in the next chapter.
 
 ## Implementing a connector in other languages
 
-You can use [buf](https://buf.build/) to generate code for building a Conduit connector in virtually any major language. To
-do that you need to create a [`buf.gen.yaml`](https://docs.buf.build/generate/usage#create-a-bufgenyaml) file and
-configure the connectors for the language you want to use.
+You can use [buf](https://buf.build/) to generate code for building a Conduit
+connector in virtually any major language. To do that you need to create
+a [`buf.gen.yaml`](https://docs.buf.build/generate/usage#create-a-bufgenyaml)
+file and configure the connectors for the language you want to use.
 
-For example here is a `buf.gen.yaml` file that is configured to generate C++ and Java code:
+For example here is a `buf.gen.yaml` file that is configured to generate C++ and
+Java code:
 
 ```yaml
 version: v1
@@ -43,24 +49,29 @@ Then you can run this command to generate the code:
 buf generate buf.build/conduitio/conduit-connector-protocol --template buf.gen.yaml
 ```
 
-At this point you should have everything you need to start developing a connector. Make sure to implement all gRPC
-services according to the documentation in the
-[proto definition](https://buf.build/conduitio/conduit-connector-protocol/file/main/connector/v1/connector.proto) and to follow
+At this point you should have everything you need to start developing a
+connector. Make sure to implement all gRPC services according to the
+documentation in the
+[proto definition](https://buf.build/conduitio/conduit-connector-protocol/file/main/connector/v1/connector.proto)
+and to follow
 the [go-plugin instructions](https://github.com/hashicorp/go-plugin/blob/master/docs/guide-plugin-write-non-go.md)
 about writing a plugin in a language other than Go.
 
-Once the connector is ready you need to create an entrypoint file which Conduit can run to start the connector. In case of
-compiled languages that is the compiled binary, in case of scripted languages you can create a simple shell script that
-starts the connector. Here is an example for python:
+Once the connector is ready you need to create an entrypoint file which Conduit
+can run to start the connector. In case of compiled languages that is the
+compiled binary, in case of scripted languages you can create a simple shell
+script that starts the connector. Here is an example for python:
 
 ```
 #!/usr/bin/env python my-connector.py
 ```
 
-To run your connector as part of a Conduit pipeline you can create it using the connectors API and specify the
-path to the compiled connector binary in the field `plugin`.
+To run your connector as part of a Conduit pipeline you can create it using the
+connectors API and specify the path to the compiled connector binary in the
+field `plugin`.
 
-Here is an example request to `POST /v1/connectors` (find more about the [Conduit API](https://github.com/conduitio/conduit#api)):
+Here is an example request to `POST /v1/connectors` (find more about
+the [Conduit API](https://github.com/conduitio/conduit#api)):
 
 ```json
 {
@@ -78,20 +89,26 @@ Here is an example request to `POST /v1/connectors` (find more about the [Condui
 
 ## Local development
 
-We are using [buf remote generation](https://docs.buf.build/bsr/remote-generation/overview) of protobuf code. When
-developing locally we don't want to push a new version of the proto files every time we make a change, that's why in
-that case we can switch to locally generated protobuf code.
+We are
+using [buf remote generation](https://docs.buf.build/bsr/remote-generation/overview)
+of protobuf code. When developing locally we don't want to push a new version of
+the proto files every time we make a change, that's why in that case we can
+switch to locally generated protobuf code.
 
 To switch to locally generated protobuf code follow the following steps:
 
 - run `cd proto && buf generate`
 - cd into the newly generated folder `internal` in the root of the project
-- create a go.mod file by running `go mod init github.com/conduitio/conduit-connector-protocol/internal`
-- cd into the root of the project and run `go mod edit -replace go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol=./internal`
+- create a go.mod file by
+  running `go mod init go.buf.build/grpc/go/conduitio/conduit-connector-protocol`
+- cd into the root of the project and
+  run `go mod edit -replace go.buf.build/grpc/go/conduitio/conduit-connector-protocol=./internal`
 
-Don't forget to revert the replace directive in the go.mod file before pushing your changes!
+Don't forget to revert the replace directive in the go.mod file before pushing
+your changes!
 
 ## Acknowledgments
 
 We took inspiration for our connector implementation from
-[hashicorp/terraform-plugin-go](https://github.com/hashicorp/terraform-plugin-go).
+[hashicorp/terraform-plugin-go](https://github.com/hashicorp/terraform-plugin-go)
+.

--- a/cpluginv1/internal/fromproto/destination.go
+++ b/cpluginv1/internal/fromproto/destination.go
@@ -16,7 +16,7 @@ package fromproto
 
 import (
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func DestinationConfigureRequest(in *connectorv1.Destination_Configure_Request) (cpluginv1.DestinationConfigureRequest, error) {

--- a/cpluginv1/internal/fromproto/record.go
+++ b/cpluginv1/internal/fromproto/record.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	opencdcv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/opencdc/v1"
+	opencdcv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/opencdc/v1"
 )
 
 func _() {

--- a/cpluginv1/internal/fromproto/record.go
+++ b/cpluginv1/internal/fromproto/record.go
@@ -19,40 +19,67 @@ import (
 	"fmt"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	opencdcv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/opencdc/v1"
 )
 
-func Record(record *connectorv1.Record) (cpluginv1.Record, error) {
-	key, err := Data(record.Key)
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	var cTypes [1]struct{}
+	_ = cTypes[int(cpluginv1.OperationCreate)-int(opencdcv1.Operation_OPERATION_CREATE)]
+	_ = cTypes[int(cpluginv1.OperationUpdate)-int(opencdcv1.Operation_OPERATION_UPDATE)]
+	_ = cTypes[int(cpluginv1.OperationDelete)-int(opencdcv1.Operation_OPERATION_DELETE)]
+	_ = cTypes[int(cpluginv1.OperationSnapshot)-int(opencdcv1.Operation_OPERATION_SNAPSHOT)]
+}
+
+func Record(record *opencdcv1.Record) (cpluginv1.Record, error) {
+	before, err := Entity(record.Before)
 	if err != nil {
-		return cpluginv1.Record{}, fmt.Errorf("error converting key: %w", err)
+		return cpluginv1.Record{}, fmt.Errorf("error converting before: %w", err)
 	}
 
-	payload, err := Data(record.Payload)
+	after, err := Entity(record.After)
 	if err != nil {
-		return cpluginv1.Record{}, fmt.Errorf("error converting payload: %w", err)
+		return cpluginv1.Record{}, fmt.Errorf("error converting after: %w", err)
 	}
 
 	out := cpluginv1.Record{
 		Position:  record.Position,
+		Operation: cpluginv1.Operation(record.Operation),
 		Metadata:  record.Metadata,
-		CreatedAt: record.CreatedAt.AsTime(),
-		Key:       key,
-		Payload:   payload,
+		Before:    before,
+		After:     after,
 	}
 	return out, nil
 }
 
-func Data(in *connectorv1.Data) (cpluginv1.Data, error) {
+func Entity(in *opencdcv1.Entity) (cpluginv1.Entity, error) {
+	key, err := Data(in.Key)
+	if err != nil {
+		return cpluginv1.Entity{}, fmt.Errorf("error converting key: %w", err)
+	}
+
+	payload, err := Data(in.Payload)
+	if err != nil {
+		return cpluginv1.Entity{}, fmt.Errorf("error converting payload: %w", err)
+	}
+
+	out := cpluginv1.Entity{
+		Key:     key,
+		Payload: payload,
+	}
+	return out, nil
+}
+
+func Data(in *opencdcv1.Data) (cpluginv1.Data, error) {
 	d := in.GetData()
 	if d == nil {
 		return nil, nil
 	}
 
 	switch v := d.(type) {
-	case *connectorv1.Data_RawData:
+	case *opencdcv1.Data_RawData:
 		return cpluginv1.RawData(v.RawData), nil
-	case *connectorv1.Data_StructuredData:
+	case *opencdcv1.Data_StructuredData:
 		return cpluginv1.StructuredData(v.StructuredData.AsMap()), nil
 	default:
 		return nil, errors.New("invalid Data type")

--- a/cpluginv1/internal/fromproto/record.go
+++ b/cpluginv1/internal/fromproto/record.go
@@ -32,40 +32,40 @@ func _() {
 }
 
 func Record(record *opencdcv1.Record) (cpluginv1.Record, error) {
-	before, err := Entity(record.Before)
+	key, err := Data(record.Key)
 	if err != nil {
-		return cpluginv1.Record{}, fmt.Errorf("error converting before: %w", err)
+		return cpluginv1.Record{}, fmt.Errorf("error converting key: %w", err)
 	}
 
-	after, err := Entity(record.After)
+	payload, err := Change(record.Payload)
 	if err != nil {
-		return cpluginv1.Record{}, fmt.Errorf("error converting after: %w", err)
+		return cpluginv1.Record{}, fmt.Errorf("error converting payload: %w", err)
 	}
 
 	out := cpluginv1.Record{
 		Position:  record.Position,
 		Operation: cpluginv1.Operation(record.Operation),
 		Metadata:  record.Metadata,
-		Before:    before,
-		After:     after,
+		Key:       key,
+		Payload:   payload,
 	}
 	return out, nil
 }
 
-func Entity(in *opencdcv1.Entity) (cpluginv1.Entity, error) {
-	key, err := Data(in.Key)
+func Change(in *opencdcv1.Change) (cpluginv1.Change, error) {
+	before, err := Data(in.Before)
 	if err != nil {
-		return cpluginv1.Entity{}, fmt.Errorf("error converting key: %w", err)
+		return cpluginv1.Change{}, fmt.Errorf("error converting before: %w", err)
 	}
 
-	payload, err := Data(in.Payload)
+	after, err := Data(in.After)
 	if err != nil {
-		return cpluginv1.Entity{}, fmt.Errorf("error converting payload: %w", err)
+		return cpluginv1.Change{}, fmt.Errorf("error converting after: %w", err)
 	}
 
-	out := cpluginv1.Entity{
-		Key:     key,
-		Payload: payload,
+	out := cpluginv1.Change{
+		Before: before,
+		After:  after,
 	}
 	return out, nil
 }

--- a/cpluginv1/internal/fromproto/source.go
+++ b/cpluginv1/internal/fromproto/source.go
@@ -16,7 +16,7 @@ package fromproto
 
 import (
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func SourceConfigureRequest(in *connectorv1.Source_Configure_Request) (cpluginv1.SourceConfigureRequest, error) {

--- a/cpluginv1/internal/fromproto/specifier.go
+++ b/cpluginv1/internal/fromproto/specifier.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func SpecifierSpecifyRequest(in *connectorv1.Specifier_Specify_Request) (cpluginv1.SpecifierSpecifyRequest, error) {

--- a/cpluginv1/internal/toproto/destination.go
+++ b/cpluginv1/internal/toproto/destination.go
@@ -16,7 +16,7 @@ package toproto
 
 import (
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func DestinationConfigureRequest(in cpluginv1.DestinationConfigureRequest) (*connectorv1.Destination_Configure_Request, error) {

--- a/cpluginv1/internal/toproto/record.go
+++ b/cpluginv1/internal/toproto/record.go
@@ -33,44 +33,40 @@ func _() {
 }
 
 func Record(record cpluginv1.Record) (*opencdcv1.Record, error) {
-	before, err := Entity(record.Before)
+	key, err := Data(record.Key)
 	if err != nil {
-		return nil, fmt.Errorf("error converting before: %w", err)
+		return nil, fmt.Errorf("error converting key: %w", err)
 	}
 
-	after, err := Entity(record.After)
+	payload, err := Change(record.Payload)
 	if err != nil {
-		return nil, fmt.Errorf("error converting after: %w", err)
+		return nil, fmt.Errorf("error converting payload: %w", err)
 	}
 
 	out := opencdcv1.Record{
 		Position:  record.Position,
 		Operation: opencdcv1.Operation(record.Operation),
 		Metadata:  record.Metadata,
-		Before:    before,
-		After:     after,
+		Key:       key,
+		Payload:   payload,
 	}
 	return &out, nil
 }
 
-func Entity(in cpluginv1.Entity) (*opencdcv1.Entity, error) {
-	key, err := Data(in.Key)
+func Change(in cpluginv1.Change) (*opencdcv1.Change, error) {
+	before, err := Data(in.Before)
 	if err != nil {
-		return nil, fmt.Errorf("error converting key: %w", err)
+		return nil, fmt.Errorf("error converting before: %w", err)
 	}
 
-	payload, err := Data(in.Payload)
+	after, err := Data(in.After)
 	if err != nil {
-		return nil, fmt.Errorf("error converting payload: %w", err)
+		return nil, fmt.Errorf("error converting after: %w", err)
 	}
 
-	if key == nil && payload == nil {
-		return nil, nil
-	}
-
-	out := opencdcv1.Entity{
-		Key:     key,
-		Payload: payload,
+	out := opencdcv1.Change{
+		Before: before,
+		After:  after,
 	}
 	return &out, nil
 }

--- a/cpluginv1/internal/toproto/record.go
+++ b/cpluginv1/internal/toproto/record.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	opencdcv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/opencdc/v1"
+	opencdcv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/opencdc/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/cpluginv1/internal/toproto/source.go
+++ b/cpluginv1/internal/toproto/source.go
@@ -16,7 +16,7 @@ package toproto
 
 import (
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func SourceConfigureRequest(in cpluginv1.SourceConfigureRequest) (*connectorv1.Source_Configure_Request, error) {

--- a/cpluginv1/internal/toproto/specifier.go
+++ b/cpluginv1/internal/toproto/specifier.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func SpecifierSpecifyRequest(in cpluginv1.SpecifierSpecifyRequest) (*connectorv1.Specifier_Specify_Request, error) {

--- a/cpluginv1/metadata.go
+++ b/cpluginv1/metadata.go
@@ -21,11 +21,11 @@ const (
 	// untyped format (e.g. JSON).
 	OpenCDCVersion = "v1"
 
-	// MetadataVersion is a Record.Metadata key for the version of the OpenCDC
-	// format (e.g. "v1"). This field exists to ensure the OpenCDC format
-	// version can be easily identified in case the record gets marshaled into a
-	// different untyped format (e.g. JSON).
-	MetadataVersion = "opencdc.version"
+	// MetadataOpenCDCVersion is a Record.Metadata key for the version of the
+	// OpenCDC format (e.g. "v1"). This field exists to ensure the OpenCDC
+	// format version can be easily identified in case the record gets marshaled
+	// into a different untyped format (e.g. JSON).
+	MetadataOpenCDCVersion = "opencdc.version"
 	// MetadataCreatedAt is a Record.Metadata key for the time when the record
 	// was created in the 3rd party system. The expected format is a unix
 	// timestamp in nanoseconds.

--- a/cpluginv1/metadata.go
+++ b/cpluginv1/metadata.go
@@ -15,6 +15,17 @@
 package cpluginv1
 
 const (
+	// OpenCDCVersion is a constant that should be used as the value in the
+	// metadata field MetadataVersion. It ensures the OpenCDC format version can
+	// be easily identified in case the record gets marshaled into a different
+	// untyped format (e.g. JSON).
+	OpenCDCVersion = "v1"
+
+	// MetadataVersion is a Record.Metadata key for the version of the OpenCDC
+	// format (e.g. "v1"). This field exists to ensure the OpenCDC format
+	// version can be easily identified in case the record gets marshaled into a
+	// different untyped format (e.g. JSON).
+	MetadataVersion = "opencdc.version"
 	// MetadataCreatedAt is a Record.Metadata key for the time when the record
 	// was created in the 3rd party system. The expected format is a unix
 	// timestamp in nanoseconds.

--- a/cpluginv1/metadata.go
+++ b/cpluginv1/metadata.go
@@ -19,39 +19,29 @@ import (
 	"fmt"
 	"strconv"
 	"time"
-
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
-	opencdcv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/opencdc/v1"
-	"google.golang.org/protobuf/proto"
 )
 
 var (
 	ErrMetadataValueNotFound = errors.New("metadata value not found")
+)
 
+const (
 	// MetadataCreatedAt is a Record.Metadata key for the time when the record
 	// was created in the 3rd party system. The expected format is a unix
 	// timestamp in nanoseconds.
-	MetadataCreatedAt string
+	MetadataCreatedAt = "opencdc.createdAt"
 	// MetadataReadAt is a Record.Metadata key for the time when the record was
 	// read from the 3rd party system. The expected format is a unix timestamp
 	// in nanoseconds.
-	MetadataReadAt string
+	MetadataReadAt = "opencdc.readAt"
 
 	// MetadataConduitPluginName is a Record.Metadata key for the name of the
 	// plugin that created this record.
-	MetadataConduitPluginName string
+	MetadataConduitPluginName = "conduit.plugin.name"
 	// MetadataConduitPluginVersion is a Record.Metadata key for the version of
 	// the plugin that created this record.
-	MetadataConduitPluginVersion string
+	MetadataConduitPluginVersion = "conduit.plugin.version"
 )
-
-func init() {
-	MetadataCreatedAt = proto.GetExtension(opencdcv1.File_opencdc_v1_opencdc_proto.Options(), opencdcv1.E_MetadataCreatedAt).(string)
-	MetadataReadAt = proto.GetExtension(opencdcv1.File_opencdc_v1_opencdc_proto.Options(), opencdcv1.E_MetadataReadAt).(string)
-
-	MetadataConduitPluginName = proto.GetExtension(connectorv1.File_connector_v1_connector_proto.Options(), connectorv1.E_MetadataConduitPluginName).(string)
-	MetadataConduitPluginVersion = proto.GetExtension(connectorv1.File_connector_v1_connector_proto.Options(), connectorv1.E_MetadataConduitPluginVersion).(string)
-}
 
 // GetMetadataCreatedAt parses the value for key MetadataCreatedAt as a unix
 // timestamp. If the value does not exist or the value is empty the function

--- a/cpluginv1/metadata.go
+++ b/cpluginv1/metadata.go
@@ -1,0 +1,138 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpluginv1
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	opencdcv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/opencdc/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	ErrMetadataValueNotFound = errors.New("metadata value not found")
+
+	// MetadataCreatedAt is a Record.Metadata key for the time when the record
+	// was created in the 3rd party system. The expected format is a unix
+	// timestamp in nanoseconds.
+	MetadataCreatedAt string
+	// MetadataReadAt is a Record.Metadata key for the time when the record was
+	// read from the 3rd party system. The expected format is a unix timestamp
+	// in nanoseconds.
+	MetadataReadAt string
+
+	// MetadataConduitPluginName is a Record.Metadata key for the name of the
+	// plugin that created this record.
+	MetadataConduitPluginName string
+	// MetadataConduitPluginVersion is a Record.Metadata key for the version of
+	// the plugin that created this record.
+	MetadataConduitPluginVersion string
+)
+
+func init() {
+	MetadataCreatedAt = proto.GetExtension(opencdcv1.File_opencdc_v1_opencdc_proto.Options(), opencdcv1.E_MetadataCreatedAt).(string)
+	MetadataReadAt = proto.GetExtension(opencdcv1.File_opencdc_v1_opencdc_proto.Options(), opencdcv1.E_MetadataReadAt).(string)
+
+	MetadataConduitPluginName = proto.GetExtension(connectorv1.File_connector_v1_connector_proto.Options(), connectorv1.E_MetadataConduitPluginName).(string)
+	MetadataConduitPluginVersion = proto.GetExtension(connectorv1.File_connector_v1_connector_proto.Options(), connectorv1.E_MetadataConduitPluginVersion).(string)
+}
+
+// GetMetadataCreatedAt parses the value for key MetadataCreatedAt as a unix
+// timestamp. If the value does not exist or the value is empty the function
+// returns ErrMetadataValueNotFound. If the value is not a valid unix timestamp
+// in nanoseconds the function returns an error.
+func GetMetadataCreatedAt(metadata map[string]string) (time.Time, error) {
+	raw := metadata[MetadataCreatedAt]
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("failed to get value for %q: %w", MetadataCreatedAt, ErrMetadataValueNotFound)
+	}
+
+	unixNano, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse value for %q: %w", MetadataCreatedAt, err)
+	}
+
+	return time.Unix(0, unixNano), nil
+}
+
+// SetMetadataCreatedAt sets the metadata value for key MetadataCreatedAt as a
+// unix timestamp in nanoseconds.
+func SetMetadataCreatedAt(metadata map[string]string, createdAt time.Time) {
+	metadata[MetadataCreatedAt] = strconv.FormatInt(createdAt.UnixNano(), 10)
+}
+
+// GetMetadataReadAt parses the value for key MetadataReadAt as a unix
+// timestamp. If the value does not exist or the value is empty the function
+// returns ErrMetadataValueNotFound. If the value is not a valid unix timestamp
+// in nanoseconds the function returns an error.
+func GetMetadataReadAt(metadata map[string]string) (time.Time, error) {
+	raw := metadata[MetadataReadAt]
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("failed to get value for %q: %w", MetadataReadAt, ErrMetadataValueNotFound)
+	}
+
+	unixNano, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse value for %q: %w", MetadataReadAt, err)
+	}
+
+	return time.Unix(0, unixNano), nil
+}
+
+// SetMetadataReadAt sets the metadata value for key MetadataReadAt as a unix
+// timestamp in nanoseconds.
+func SetMetadataReadAt(metadata map[string]string, createdAt time.Time) {
+	metadata[MetadataReadAt] = strconv.FormatInt(createdAt.UnixNano(), 10)
+}
+
+// GetMetadataConduitPluginName returns the value for key
+// MetadataConduitPluginName. If the value is does not exist or is empty the
+// function returns ErrMetadataValueNotFound.
+func GetMetadataConduitPluginName(metadata map[string]string) (string, error) {
+	return getMetadataValue(metadata, MetadataConduitPluginName)
+}
+
+// SetMetadataConduitPluginName sets the metadata value for key
+// MetadataConduitPluginName.
+func SetMetadataConduitPluginName(metadata map[string]string, name string) {
+	metadata[MetadataConduitPluginName] = name
+}
+
+// GetMetadataConduitPluginVersion returns the value for key
+// MetadataConduitPluginVersion. If the value is does not exist or is empty the
+// function returns ErrMetadataValueNotFound.
+func GetMetadataConduitPluginVersion(metadata map[string]string) (string, error) {
+	return getMetadataValue(metadata, MetadataConduitPluginVersion)
+}
+
+// SetMetadataConduitPluginVersion sets the metadata value for key
+// MetadataConduitPluginVersion.
+func SetMetadataConduitPluginVersion(metadata map[string]string, version string) {
+	metadata[MetadataConduitPluginVersion] = version
+}
+
+// getMetadataValue returns the value for a specific key. If the value is does
+// not exist or is empty the function returns ErrMetadataValueNotFound.
+func getMetadataValue(metadata map[string]string, key string) (string, error) {
+	str := metadata[key]
+	if str == "" {
+		return "", fmt.Errorf("failed to get value for %q: %w", key, ErrMetadataValueNotFound)
+	}
+	return str, nil
+}

--- a/cpluginv1/metadata.go
+++ b/cpluginv1/metadata.go
@@ -14,17 +14,6 @@
 
 package cpluginv1
 
-import (
-	"errors"
-	"fmt"
-	"strconv"
-	"time"
-)
-
-var (
-	ErrMetadataValueNotFound = errors.New("metadata value not found")
-)
-
 const (
 	// MetadataCreatedAt is a Record.Metadata key for the time when the record
 	// was created in the 3rd party system. The expected format is a unix
@@ -42,87 +31,3 @@ const (
 	// the plugin that created this record.
 	MetadataConduitPluginVersion = "conduit.plugin.version"
 )
-
-// GetMetadataCreatedAt parses the value for key MetadataCreatedAt as a unix
-// timestamp. If the value does not exist or the value is empty the function
-// returns ErrMetadataValueNotFound. If the value is not a valid unix timestamp
-// in nanoseconds the function returns an error.
-func GetMetadataCreatedAt(metadata map[string]string) (time.Time, error) {
-	raw := metadata[MetadataCreatedAt]
-	if raw == "" {
-		return time.Time{}, fmt.Errorf("failed to get value for %q: %w", MetadataCreatedAt, ErrMetadataValueNotFound)
-	}
-
-	unixNano, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to parse value for %q: %w", MetadataCreatedAt, err)
-	}
-
-	return time.Unix(0, unixNano), nil
-}
-
-// SetMetadataCreatedAt sets the metadata value for key MetadataCreatedAt as a
-// unix timestamp in nanoseconds.
-func SetMetadataCreatedAt(metadata map[string]string, createdAt time.Time) {
-	metadata[MetadataCreatedAt] = strconv.FormatInt(createdAt.UnixNano(), 10)
-}
-
-// GetMetadataReadAt parses the value for key MetadataReadAt as a unix
-// timestamp. If the value does not exist or the value is empty the function
-// returns ErrMetadataValueNotFound. If the value is not a valid unix timestamp
-// in nanoseconds the function returns an error.
-func GetMetadataReadAt(metadata map[string]string) (time.Time, error) {
-	raw := metadata[MetadataReadAt]
-	if raw == "" {
-		return time.Time{}, fmt.Errorf("failed to get value for %q: %w", MetadataReadAt, ErrMetadataValueNotFound)
-	}
-
-	unixNano, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to parse value for %q: %w", MetadataReadAt, err)
-	}
-
-	return time.Unix(0, unixNano), nil
-}
-
-// SetMetadataReadAt sets the metadata value for key MetadataReadAt as a unix
-// timestamp in nanoseconds.
-func SetMetadataReadAt(metadata map[string]string, createdAt time.Time) {
-	metadata[MetadataReadAt] = strconv.FormatInt(createdAt.UnixNano(), 10)
-}
-
-// GetMetadataConduitPluginName returns the value for key
-// MetadataConduitPluginName. If the value is does not exist or is empty the
-// function returns ErrMetadataValueNotFound.
-func GetMetadataConduitPluginName(metadata map[string]string) (string, error) {
-	return getMetadataValue(metadata, MetadataConduitPluginName)
-}
-
-// SetMetadataConduitPluginName sets the metadata value for key
-// MetadataConduitPluginName.
-func SetMetadataConduitPluginName(metadata map[string]string, name string) {
-	metadata[MetadataConduitPluginName] = name
-}
-
-// GetMetadataConduitPluginVersion returns the value for key
-// MetadataConduitPluginVersion. If the value is does not exist or is empty the
-// function returns ErrMetadataValueNotFound.
-func GetMetadataConduitPluginVersion(metadata map[string]string) (string, error) {
-	return getMetadataValue(metadata, MetadataConduitPluginVersion)
-}
-
-// SetMetadataConduitPluginVersion sets the metadata value for key
-// MetadataConduitPluginVersion.
-func SetMetadataConduitPluginVersion(metadata map[string]string, version string) {
-	metadata[MetadataConduitPluginVersion] = version
-}
-
-// getMetadataValue returns the value for a specific key. If the value is does
-// not exist or is empty the function returns ErrMetadataValueNotFound.
-func getMetadataValue(metadata map[string]string, key string) (string, error) {
-	str := metadata[key]
-	if str == "" {
-		return "", fmt.Errorf("failed to get value for %q: %w", key, ErrMetadataValueNotFound)
-	}
-	return str, nil
-}

--- a/cpluginv1/metadata_test.go
+++ b/cpluginv1/metadata_test.go
@@ -1,0 +1,39 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpluginv1
+
+import (
+	"testing"
+
+	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	opencdcv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/opencdc/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/runtime/protoimpl"
+)
+
+func TestMetadataConstants(t *testing.T) {
+	wantMapping := map[string]*protoimpl.ExtensionInfo{
+		MetadataCreatedAt:            opencdcv1.E_MetadataCreatedAt,
+		MetadataReadAt:               opencdcv1.E_MetadataReadAt,
+		MetadataConduitPluginName:    connectorv1.E_MetadataConduitPluginName,
+		MetadataConduitPluginVersion: connectorv1.E_MetadataConduitPluginVersion,
+	}
+	for goConstant, extensionInfo := range wantMapping {
+		protoConstant := proto.GetExtension(extensionInfo.TypeDescriptor().ParentFile().Options(), extensionInfo)
+		if goConstant != protoConstant {
+			t.Fatalf("go constant %q doesn't match proto constant %q", goConstant, protoConstant)
+		}
+	}
+}

--- a/cpluginv1/metadata_test.go
+++ b/cpluginv1/metadata_test.go
@@ -26,7 +26,7 @@ import (
 func TestMetadataConstants(t *testing.T) {
 	wantMapping := map[string]*protoimpl.ExtensionInfo{
 		OpenCDCVersion:               opencdcv1.E_OpencdcVersion,
-		MetadataVersion:              opencdcv1.E_MetadataVersion,
+		MetadataOpenCDCVersion:       opencdcv1.E_MetadataVersion,
 		MetadataCreatedAt:            opencdcv1.E_MetadataCreatedAt,
 		MetadataReadAt:               opencdcv1.E_MetadataReadAt,
 		MetadataConduitPluginName:    connectorv1.E_MetadataConduitPluginName,

--- a/cpluginv1/metadata_test.go
+++ b/cpluginv1/metadata_test.go
@@ -25,6 +25,8 @@ import (
 
 func TestMetadataConstants(t *testing.T) {
 	wantMapping := map[string]*protoimpl.ExtensionInfo{
+		OpenCDCVersion:               opencdcv1.E_OpencdcVersion,
+		MetadataVersion:              opencdcv1.E_MetadataVersion,
 		MetadataCreatedAt:            opencdcv1.E_MetadataCreatedAt,
 		MetadataReadAt:               opencdcv1.E_MetadataReadAt,
 		MetadataConduitPluginName:    connectorv1.E_MetadataConduitPluginName,

--- a/cpluginv1/metadata_test.go
+++ b/cpluginv1/metadata_test.go
@@ -17,8 +17,8 @@ package cpluginv1
 import (
 	"testing"
 
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
-	opencdcv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/opencdc/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
+	opencdcv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/opencdc/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/runtime/protoimpl"
 )

--- a/cpluginv1/record.go
+++ b/cpluginv1/record.go
@@ -27,13 +27,13 @@ type Record struct {
 	Position  []byte
 	Operation Operation
 	Metadata  map[string]string
-	Before    Entity
-	After     Entity
+	Key       Data
+	Payload   Change
 }
 
-type Entity struct {
-	Key     Data
-	Payload Data
+type Change struct {
+	Before Data
+	After  Data
 }
 
 type Data interface {

--- a/cpluginv1/record.go
+++ b/cpluginv1/record.go
@@ -14,14 +14,26 @@
 
 package cpluginv1
 
-import "time"
+const (
+	OperationCreate Operation = iota + 1
+	OperationUpdate
+	OperationDelete
+	OperationSnapshot
+)
+
+type Operation int
 
 type Record struct {
 	Position  []byte
+	Operation Operation
 	Metadata  map[string]string
-	CreatedAt time.Time
-	Key       Data
-	Payload   Data
+	Before    Entity
+	After     Entity
+}
+
+type Entity struct {
+	Key     Data
+	Payload Data
 }
 
 type Data interface {

--- a/cpluginv1/server/destination.go
+++ b/cpluginv1/server/destination.go
@@ -20,7 +20,7 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1/internal/fromproto"
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1/internal/toproto"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func NewDestinationPluginServer(impl cpluginv1.DestinationPlugin) connectorv1.DestinationPluginServer {

--- a/cpluginv1/server/serve.go
+++ b/cpluginv1/server/serve.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
 	"github.com/hashicorp/go-plugin"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 	"google.golang.org/grpc"
 )
 

--- a/cpluginv1/server/source.go
+++ b/cpluginv1/server/source.go
@@ -20,7 +20,7 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1/internal/fromproto"
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1/internal/toproto"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func NewSourcePluginServer(impl cpluginv1.SourcePlugin) connectorv1.SourcePluginServer {

--- a/cpluginv1/server/specifier.go
+++ b/cpluginv1/server/specifier.go
@@ -20,7 +20,7 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1/internal/fromproto"
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1/internal/toproto"
-	connectorv1 "go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol/connector/v1"
+	connectorv1 "go.buf.build/grpc/go/conduitio/conduit-connector-protocol/connector/v1"
 )
 
 func NewSpecifierPluginServer(impl cpluginv1.SpecifierPlugin) connectorv1.SpecifierPluginServer {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-plugin v1.4.3
-	go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol v1.4.2
+	go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.3.3
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol v1.4.2 h1:r7UZqQXoHpfLucOFKTSRiNLdZ0XG/AUupkr+Kkgth+A=
-go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol v1.4.2/go.mod h1:iYPhlwHzhRoPYviJbA604qT6wYuQghfrebmXUXLKjk8=
+go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.3.3 h1:Nlr9Dm1z7OoG4S1ic1yuwVU8oreR2eFofiJt5v8+zok=
+go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.3.3/go.mod h1:0IIr2GMOsGd1hPPfwQMmXMXnME6jZSER4C2JS/+BrLc=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -187,9 +187,9 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
   go_package_prefix:
-    default: go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol
+    default: go.buf.build/grpc/go/conduitio/conduit-connector-protocol
 plugins:
   - name: go
     out: ../internal


### PR DESCRIPTION
This adds the Go binding for OpenCDC records and metadata fields.

Depends on #8 (needs to be merged, schema pushed to BSR and then go.mod updated to use new generated code).

Closes https://github.com/ConduitIO/conduit/issues/509.