### PR TITLE
Adds handling of metadata and errors

### DIFF
--- a/pconduit/context.go
+++ b/pconduit/context.go
@@ -1,0 +1,34 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pconduit
+
+import "context"
+
+type connectorTokenCtxKey struct{}
+
+// ContextWithConnectorToken wraps ctx and returns a context that contains the connector token.
+func ContextWithConnectorToken(ctx context.Context, connectorToken string) context.Context {
+	return context.WithValue(ctx, connectorTokenCtxKey{}, connectorToken)
+}
+
+// ConnectorTokenFromContext fetches the connector token from the context. If the
+// context does not contain a connector token it returns an empty string.
+func ConnectorTokenFromContext(ctx context.Context) string {
+	connectorToken := ctx.Value(connectorTokenCtxKey{})
+	if connectorToken != nil {
+		return connectorToken.(string)
+	}
+	return ""
+}

--- a/pconduit/context.go
+++ b/pconduit/context.go
@@ -28,7 +28,7 @@ func ContextWithConnectorToken(ctx context.Context, connectorToken string) conte
 func ConnectorTokenFromContext(ctx context.Context) string {
 	connectorToken := ctx.Value(connectorTokenCtxKey{})
 	if connectorToken != nil {
-		return connectorToken.(string)
+		return connectorToken.(string) //nolint:forcetypeassert // only this package can set the value, it has to be a string
 	}
 	return ""
 }

--- a/pconduit/errors.go
+++ b/pconduit/errors.go
@@ -16,4 +16,11 @@ package pconduit
 
 import "errors"
 
-var ErrUnimplemented = errors.New("method not implemented")
+var (
+	ErrUnimplemented = errors.New("method not implemented")
+
+	ErrSchemaNotFound       = errors.New("schema not found")
+	ErrInvalidSchemaSubject = errors.New("invalid schema subject")
+	ErrInvalidSchemaType    = errors.New("invalid schema type")
+	ErrInvalidSchemaBytes   = errors.New("invalid schema bytes")
+)

--- a/pconduit/internal/metadata.go
+++ b/pconduit/internal/metadata.go
@@ -1,0 +1,46 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+
+	"github.com/conduitio/conduit-connector-protocol/pconduit"
+	"google.golang.org/grpc/metadata"
+)
+
+const MetadataConnectorTokenKey = "conduit-connector-token"
+
+// RepackConnectorTokenOutgoingContext takes the connector token from ctx using
+// pconduit.ConnectorTokenFromContext and repacks it into gRPC metadata so it can
+// be sent to the server.
+func RepackConnectorTokenOutgoingContext(ctx context.Context) context.Context {
+	token := pconduit.ConnectorTokenFromContext(ctx)
+	if token == "" {
+		return ctx // no connector token attached
+	}
+	return metadata.AppendToOutgoingContext(ctx, MetadataConnectorTokenKey, token)
+}
+
+// RepackConnectorTokenIncomingContext takes the connector token from the gRPC
+// metadata and repacks it into the context so it can be retrieved using
+// pconduit.ConnectorTokenFromContext.
+func RepackConnectorTokenIncomingContext(ctx context.Context) context.Context {
+	token := metadata.ValueFromIncomingContext(ctx, MetadataConnectorTokenKey)
+	if len(token) == 0 {
+		return ctx // no connector token attached
+	}
+	return pconduit.ContextWithConnectorToken(ctx, token[0])
+}

--- a/pconduit/v1/client/schema.go
+++ b/pconduit/v1/client/schema.go
@@ -36,6 +36,7 @@ func NewSchemaServiceClient(cc *grpc.ClientConn) *SchemaServiceClient {
 }
 
 func (c *SchemaServiceClient) CreateSchema(ctx context.Context, request pconduit.CreateSchemaRequest) (pconduit.CreateSchemaResponse, error) {
+	ctx = internal.RepackConnectorTokenOutgoingContext(ctx)
 	protoReq := toproto.CreateSchemaRequest(request)
 	protoResp, err := c.grpcClient.CreateSchema(ctx, protoReq)
 	if err != nil {
@@ -45,6 +46,7 @@ func (c *SchemaServiceClient) CreateSchema(ctx context.Context, request pconduit
 }
 
 func (c *SchemaServiceClient) GetSchema(ctx context.Context, request pconduit.GetSchemaRequest) (pconduit.GetSchemaResponse, error) {
+	ctx = internal.RepackConnectorTokenOutgoingContext(ctx)
 	protoReq := toproto.GetSchemaRequest(request)
 	protoResp, err := c.grpcClient.GetSchema(ctx, protoReq)
 	if err != nil {

--- a/pconduit/v1/server/schema.go
+++ b/pconduit/v1/server/schema.go
@@ -1,0 +1,54 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/conduitio/conduit-connector-protocol/pconduit"
+	"github.com/conduitio/conduit-connector-protocol/pconduit/internal"
+	"github.com/conduitio/conduit-connector-protocol/pconduit/v1/fromproto"
+	"github.com/conduitio/conduit-connector-protocol/pconduit/v1/toproto"
+	conduitv1 "github.com/conduitio/conduit-connector-protocol/proto/conduit/v1"
+)
+
+func NewSchemaServiceServer(impl pconduit.SchemaService) conduitv1.SchemaServiceServer {
+	return &schemaServiceServer{impl: impl}
+}
+
+type schemaServiceServer struct {
+	conduitv1.UnimplementedSchemaServiceServer
+	impl pconduit.SchemaService
+}
+
+func (s *schemaServiceServer) CreateSchema(ctx context.Context, protoReq *conduitv1.CreateSchemaRequest) (*conduitv1.CreateSchemaResponse, error) {
+	ctx = internal.RepackConnectorTokenIncomingContext(ctx)
+	goReq := fromproto.CreateSchemaRequest(protoReq)
+	goResp, err := s.impl.CreateSchema(ctx, goReq)
+	if err != nil {
+		return nil, err
+	}
+	return toproto.CreateSchemaResponse(goResp)
+}
+
+func (s *schemaServiceServer) GetSchema(ctx context.Context, protoReq *conduitv1.GetSchemaRequest) (*conduitv1.GetSchemaResponse, error) {
+	ctx = internal.RepackConnectorTokenIncomingContext(ctx)
+	goReq := fromproto.GetSchemaRequest(protoReq)
+	goResp, err := s.impl.GetSchema(ctx, goReq)
+	if err != nil {
+		return nil, err
+	}
+	return toproto.GetSchemaResponse(goResp)
+}


### PR DESCRIPTION
### Description

* Adds `pconduit/v1/server/schema.go` which contains the schema service server.
* Defines known schema service errors in `pconduit/errors.go`.
* Includes the added errors in `internal.UnwrapGRPCError`.
* Adds functions to add and retrieve the connector token from a context.
* Adds functions to repack the connector token from a context into gRPC metadata and vice-versa.
* Configures the client and server to handle the connector token in requests.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-protocol/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
